### PR TITLE
SL-1137: add revert for delete hearing action

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sandl/snlevents/mappers/FactsMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/sandl/snlevents/mappers/FactsMapper.java
@@ -135,7 +135,6 @@ public class FactsMapper {
     public String mapDbHearingToRuleJsonMessage(Hearing hearing) throws JsonProcessingException {
         FactHearingPart factHearingPart = new FactHearingPart();
 
-        factHearingPart.setId(hearing.getId().toString());
         factHearingPart.setDuration(hearing.getDuration());
         factHearingPart.setCaseTypeCode(hearing.getCaseType().getCode());
         factHearingPart.setHearingTypeCode(hearing.getHearingType().getCode());
@@ -144,6 +143,8 @@ public class FactsMapper {
         factHearingPart.setCreatedAt(hearing.getCreatedAt());
 
         HearingPart hearingPart = hearing.getHearingParts().get(0); // @TODO temporary solution
+        factHearingPart.setId(hearingPart.getId().toString());
+
         if (hearingPart.getSessionId() != null) {
             factHearingPart.setSessionId(hearingPart.getSessionId().toString());
         }

--- a/src/main/java/uk/gov/hmcts/reform/sandl/snlevents/mappers/FactsMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/sandl/snlevents/mappers/FactsMapper.java
@@ -210,7 +210,7 @@ public class FactsMapper {
         Hearing hearing = hearingPart.getHearing();
         FactHearingPart factHearingPart = new FactHearingPart();
 
-        factHearingPart.setId(hearing.getId().toString());
+        factHearingPart.setId(hearingPart.getId().toString());
         factHearingPart.setDuration(hearing.getDuration());
         factHearingPart.setCaseTypeCode(hearing.getCaseType().getCode());
         factHearingPart.setHearingTypeCode(hearing.getHearingType().getCode());

--- a/src/main/java/uk/gov/hmcts/reform/sandl/snlevents/model/db/HearingPart.java
+++ b/src/main/java/uk/gov/hmcts/reform/sandl/snlevents/model/db/HearingPart.java
@@ -48,8 +48,6 @@ public class HearingPart extends VersionedEntity implements Serializable, Histor
     @Column(name = "session_id", updatable = false, insertable = false)
     private UUID sessionId;
 
-    //private OffsetDateTime start;
-
     private boolean isDeleted;
 
     @CreatedDate

--- a/src/main/java/uk/gov/hmcts/reform/sandl/snlevents/repository/db/HearingPartRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/sandl/snlevents/repository/db/HearingPartRepository.java
@@ -26,6 +26,9 @@ public interface HearingPartRepository extends JpaRepository<HearingPart, UUID> 
     @Query(value = "select hp from HearingPart hp JOIN FETCH hp.hearing where hp.id = :uuid")
     HearingPart findById(@Param("uuid") UUID uuid);
 
+    @Query(nativeQuery = true, value = "select * from hearing_part where hearing_id=:1")
+    List<HearingPart> getHearingPartsByHearingIdIgnoringWhereDeletedClause(UUID id);
+
     @Query(nativeQuery = true,
         value = "select cast(title as varchar(100)) as title, cast(hearings as int) as hearings, \n"
             + "cast(minutes as int) as minutes \n"

--- a/src/main/java/uk/gov/hmcts/reform/sandl/snlevents/repository/db/HearingRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/sandl/snlevents/repository/db/HearingRepository.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.sandl.snlevents.repository.db;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.reform.sandl.snlevents.model.db.Hearing;
 
@@ -9,4 +10,7 @@ import java.util.UUID;
 
 @Repository
 public interface HearingRepository extends JpaRepository<Hearing, UUID>, JpaSpecificationExecutor<Hearing> {
+
+    @Query(nativeQuery = true, value = "select * from hearing where id=:1")
+    Hearing getHearingByIdIgnoringWhereDeletedClause(UUID id);
 }

--- a/src/main/java/uk/gov/hmcts/reform/sandl/snlevents/service/FactMessageService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sandl/snlevents/service/FactMessageService.java
@@ -19,16 +19,18 @@ public class FactMessageService {
     private ProblemService problemService;
 
     public void handle(UUID userTransactionId, String factMsg) {
-        try {
-            JsonNode modifications = objectMapper.readTree(factMsg);
+        if (factMsg != null) {
+            try {
+                JsonNode modifications = objectMapper.readTree(factMsg);
 
-            for (JsonNode item : modifications) {
-                if ("Problem".equals(item.get("type").asText())) {
-                    handleProblem(userTransactionId, item);
+                for (JsonNode item : modifications) {
+                    if ("Problem".equals(item.get("type").asText())) {
+                        handleProblem(userTransactionId, item);
+                    }
                 }
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
             }
-        } catch (IOException ex) {
-            throw new RuntimeException(ex);
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/sandl/snlevents/service/RevertChangesManager.java
+++ b/src/main/java/uk/gov/hmcts/reform/sandl/snlevents/service/RevertChangesManager.java
@@ -102,6 +102,17 @@ public class RevertChangesManager {
 
             hearingPartRepository.save(hearingParts);
             hearingRepository.save(hearing);
+
+            hearingParts.forEach(hp -> {
+                String msg;
+                try {
+                    msg = factsMapper.mapHearingPartToRuleJsonMessage(hp);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+
+                rulesService.postMessage(utd.getUserTransactionId(), RulesService.UPSERT_HEARING_PART, msg);
+            });
         }
 
     }

--- a/src/main/java/uk/gov/hmcts/reform/sandl/snlevents/service/RevertChangesManager.java
+++ b/src/main/java/uk/gov/hmcts/reform/sandl/snlevents/service/RevertChangesManager.java
@@ -92,6 +92,16 @@ public class RevertChangesManager {
             hearingRepository.save(previousHearing);
         } else if ("delete".equals(utd.getCounterAction())) {
             hearingRepository.delete(utd.getEntityId());
+        } else if ("create".equals(utd.getCounterAction())) {
+            hearing = hearingRepository.getHearingByIdIgnoringWhereDeletedClause(utd.getEntityId());
+            hearing.setDeleted(false);
+
+            List<HearingPart> hearingParts = hearingPartRepository
+                .getHearingPartsByHearingIdIgnoringWhereDeletedClause(hearing.getId());
+            hearingParts.forEach(hp -> hp.setDeleted(false));
+
+            hearingPartRepository.save(hearingParts);
+            hearingRepository.save(hearing);
         }
 
     }

--- a/src/test/java/uk/gov/hmcts/reform/sandl/snlevents/actions/UpdateListingRequestActionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sandl/snlevents/actions/UpdateListingRequestActionTest.java
@@ -43,6 +43,7 @@ public class UpdateListingRequestActionTest {
     private static final String HEARING_TYPE_CODE = "hearing-type-code";
     private static final HearingType HEARING_TYPE = new HearingType(HEARING_TYPE_CODE, "hearing-type-description");
     private static final CaseType CASE_TYPE = new CaseType(CASE_TYPE_CODE, "case-type-description");
+    private static final UUID HP_ID = UUID.randomUUID();
 
     private UpdateListingRequestAction action;
     private UpdateListingRequest ulr;
@@ -83,7 +84,7 @@ public class UpdateListingRequestActionTest {
         hearing.setId(createUuid(ID));
         hearing.setCaseType(new CaseType());
         hearing.setHearingType(new HearingType());
-        hearing.setHearingParts(Arrays.asList(new HearingPart()));
+        hearing.setHearingParts(Arrays.asList(createHearingPart()));
 
         Mockito.when(hearingRepository.findOne(createUuid(ID))).thenReturn(hearing);
         when(hearingRepository.save(Matchers.any(Hearing.class))).thenReturn(hearing);
@@ -145,7 +146,7 @@ public class UpdateListingRequestActionTest {
         );
 
         expectedTransactionData.add(new UserTransactionData("hearingPart",
-            null,
+            HP_ID,
             null,
             "lock",
             "unlock",
@@ -161,6 +162,12 @@ public class UpdateListingRequestActionTest {
         assertThat(actualTransactionData).isEqualTo(expectedTransactionData);
     }
 
+    private HearingPart createHearingPart() {
+        HearingPart hearingPart = new HearingPart();
+        hearingPart.setId(HP_ID);
+
+        return hearingPart;
+    }
 
     private UUID createUuid(String uuid) {
         return UUID.fromString(uuid);

--- a/src/test/java/uk/gov/hmcts/reform/sandl/snlevents/mappers/FactsMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sandl/snlevents/mappers/FactsMapperTest.java
@@ -51,7 +51,7 @@ public class FactsMapperTest {
     private static final String SESSION_ID = "83537f81-b730-4754-aba4-0277b7882824";
     private static final String PERSON_ID = "1fa92e14-ce0e-4a1f-b352-53f1581d771f";
     private static final String ROOM_ID = "3a8b6e05-afb9-4b2a-b87d-152971d0607a";
-    private static final UUID HP_ID = UUID.randomUUID();
+    private static final String HP_ID = "d26119ab-f3fa-47c9-9733-047b744a0c8a";
 
     public static final int VALUE = 123;
     private static final String PERSON_NAME = "Grzesiek";
@@ -100,7 +100,7 @@ public class FactsMapperTest {
         h.setScheduleEnd(END);
         h.setCreatedAt(START);
         val hp = new HearingPart();
-        hp.setId(HP_ID);
+        hp.setId(createUuid(HP_ID));
         hp.setSessionId(createUuid(SESSION_ID));
         h.setHearingParts(Arrays.asList(hp));
 
@@ -117,6 +117,7 @@ public class FactsMapperTest {
         h.setScheduleEnd(END);
         h.setCreatedAt(START);
         val hp = new HearingPart();
+        hp.setId(createUuid(HP_ID));
         hp.setSessionId(createUuid(SESSION_ID));
         h.setHearingParts(Arrays.asList(hp));
         hp.setHearing(h);
@@ -208,7 +209,7 @@ public class FactsMapperTest {
     @Test
     public void mapHearingPartToRuleJsonMessage_mapsOk() throws JsonProcessingException {
         val mapped = factsMapper.mapHearingPartToRuleJsonMessage(createHearingPart());
-        val expected = "{\"id\":\"123e4567-e89b-12d3-a456-426655440000\","
+        val expected = "{\"id\":\"d26119ab-f3fa-47c9-9733-047b744a0c8a\","
             + "\"sessionId\":null,"
             + "\"caseTypeCode\":\"case-type\","
             + "\"hearingTypeCode\":\"hearing-type-2\","

--- a/src/test/java/uk/gov/hmcts/reform/sandl/snlevents/mappers/FactsMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sandl/snlevents/mappers/FactsMapperTest.java
@@ -144,7 +144,7 @@ public class FactsMapperTest {
     public void mapDbHearingToRuleJsonMessage_mapsOk() throws JsonProcessingException {
         val mapped = factsMapper.mapDbHearingToRuleJsonMessage(createHearing());
         val expected = "{"
-            + "\"id\":\"" + HP_IDrn t + "\","
+            + "\"id\":\"" + HP_ID + "\","
             + "\"sessionId\":\"" + SESSION_ID + "\","
             + "\"caseTypeCode\":\"" + CASE_TYPE_CODE + "\","
             + "\"hearingTypeCode\":\"" + HEARING_TYPE_CODE + "\","

--- a/src/test/java/uk/gov/hmcts/reform/sandl/snlevents/mappers/FactsMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sandl/snlevents/mappers/FactsMapperTest.java
@@ -51,6 +51,7 @@ public class FactsMapperTest {
     private static final String SESSION_ID = "83537f81-b730-4754-aba4-0277b7882824";
     private static final String PERSON_ID = "1fa92e14-ce0e-4a1f-b352-53f1581d771f";
     private static final String ROOM_ID = "3a8b6e05-afb9-4b2a-b87d-152971d0607a";
+    private static final UUID HP_ID = UUID.randomUUID();
 
     public static final int VALUE = 123;
     private static final String PERSON_NAME = "Grzesiek";
@@ -99,6 +100,7 @@ public class FactsMapperTest {
         h.setScheduleEnd(END);
         h.setCreatedAt(START);
         val hp = new HearingPart();
+        hp.setId(HP_ID);
         hp.setSessionId(createUuid(SESSION_ID));
         h.setHearingParts(Arrays.asList(hp));
 
@@ -142,7 +144,7 @@ public class FactsMapperTest {
     public void mapDbHearingToRuleJsonMessage_mapsOk() throws JsonProcessingException {
         val mapped = factsMapper.mapDbHearingToRuleJsonMessage(createHearing());
         val expected = "{"
-            + "\"id\":\"" + ID + "\","
+            + "\"id\":\"" + HP_IDrn t + "\","
             + "\"sessionId\":\"" + SESSION_ID + "\","
             + "\"caseTypeCode\":\"" + CASE_TYPE_CODE + "\","
             + "\"hearingTypeCode\":\"" + HEARING_TYPE_CODE + "\","


### PR DESCRIPTION
Native queries are introduced, because of @Where annotation used on Hearing and HearingPart entities, currently it's not possible to get these entities if they're deleted. It's the quickest workaround atm.