### PR TITLE
[PREVIEW] feature/sl 1798/prevent move multisession planner

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sandl/snlevents/actions/hearingpart/AssignHearingPartToSessionAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sandl/snlevents/actions/hearingpart/AssignHearingPartToSessionAction.java
@@ -72,7 +72,7 @@ public class AssignHearingPartToSessionAction extends Action implements RulesPro
         }
 
         if (hearingPart.getHearing().isMultiSession()) {
-            throw new SnlEventsException("Hearing part cannot be part of a multi-session!");
+            throw new SnlEventsException("Cannot assign hearing part which is a part of a multi-session!");
         }
 
         targetSession = sessionRepository.findOne(relationship.getSessionData().getSessionId());

--- a/src/main/java/uk/gov/hmcts/reform/sandl/snlevents/actions/hearingpart/AssignHearingPartToSessionAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sandl/snlevents/actions/hearingpart/AssignHearingPartToSessionAction.java
@@ -62,12 +62,17 @@ public class AssignHearingPartToSessionAction extends Action implements RulesPro
     @Override
     public void getAndValidateEntities() {
         hearingPart = hearingPartRepository.findOne(hearingPartId);
+
         if (hearingPart == null) {
             throw new SnlEventsException("Hearing part cannot be null!");
         }
         // this below might be wrong, but the thinking behind is that it has to be first unlisted and the listed again
         if (!statusServiceManager.canBeListed(hearingPart)) {
             throw new SnlEventsException("Hearing part can not be listed");
+        }
+
+        if (hearingPart.getHearing().isMultiSession()) {
+            throw new SnlEventsException("Hearing part cannot be part of a multi-session!");
         }
 
         targetSession = sessionRepository.findOne(relationship.getSessionData().getSessionId());

--- a/src/test/java/uk/gov/hmcts/reform/sandl/snlevents/actions/hearingpart/AssignHearingPartToSessionActionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sandl/snlevents/actions/hearingpart/AssignHearingPartToSessionActionTest.java
@@ -23,6 +23,7 @@ import uk.gov.hmcts.reform.sandl.snlevents.model.db.UserTransactionData;
 import uk.gov.hmcts.reform.sandl.snlevents.model.request.HearingPartSessionRelationship;
 import uk.gov.hmcts.reform.sandl.snlevents.model.request.SessionAssignmentData;
 import uk.gov.hmcts.reform.sandl.snlevents.repository.db.HearingPartRepository;
+import uk.gov.hmcts.reform.sandl.snlevents.repository.db.HearingRepository;
 import uk.gov.hmcts.reform.sandl.snlevents.repository.db.SessionRepository;
 import uk.gov.hmcts.reform.sandl.snlevents.service.RulesService;
 
@@ -128,6 +129,12 @@ public class AssignHearingPartToSessionActionTest {
         assertThat(action.hearingPart.getStart()).isEqualTo(mockedSession.getStart());
 
         Mockito.verify(objectMapper, times(2)).writeValueAsString(any());
+    }
+
+    @Test(expected = SnlEventsException.class)
+    public void act_shouldThrowServiceException_whenHearingIsMultiSession() {
+        mockedHearingPart.getHearing().setMultiSession(true);
+        action.getAndValidateEntities();
     }
 
     @Test(expected = SnlEventsException.class)

--- a/src/test/java/uk/gov/hmcts/reform/sandl/snlevents/actions/hearingpart/AssignHearingPartToSessionActionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sandl/snlevents/actions/hearingpart/AssignHearingPartToSessionActionTest.java
@@ -23,7 +23,6 @@ import uk.gov.hmcts.reform.sandl.snlevents.model.db.UserTransactionData;
 import uk.gov.hmcts.reform.sandl.snlevents.model.request.HearingPartSessionRelationship;
 import uk.gov.hmcts.reform.sandl.snlevents.model.request.SessionAssignmentData;
 import uk.gov.hmcts.reform.sandl.snlevents.repository.db.HearingPartRepository;
-import uk.gov.hmcts.reform.sandl.snlevents.repository.db.HearingRepository;
 import uk.gov.hmcts.reform.sandl.snlevents.repository.db.SessionRepository;
 import uk.gov.hmcts.reform.sandl.snlevents.service.RulesService;
 

--- a/src/test/java/uk/gov/hmcts/reform/sandl/snlevents/actions/hearingpart/AssignHearingPartToSessionActionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sandl/snlevents/actions/hearingpart/AssignHearingPartToSessionActionTest.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.val;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -66,6 +68,9 @@ public class AssignHearingPartToSessionActionTest {
     @Mock
     private ObjectMapper objectMapper;
     private final HearingPart mockedHearingPart = new HearingPart();
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void setup() {
@@ -130,8 +135,10 @@ public class AssignHearingPartToSessionActionTest {
         Mockito.verify(objectMapper, times(2)).writeValueAsString(any());
     }
 
-    @Test(expected = SnlEventsException.class)
+    @Test
     public void act_shouldThrowServiceException_whenHearingIsMultiSession() {
+        expectedException.expect(SnlEventsException.class);
+        expectedException.expectMessage("Cannot assign hearing part which is a part of a multi-session!");
         mockedHearingPart.getHearing().setMultiSession(true);
         action.getAndValidateEntities();
     }


### PR DESCRIPTION
### Change description ###
Added SnlEventsException if hearing is a multi-session and added a test


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
